### PR TITLE
Remove debug scripts from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,8 +64,7 @@
     <script>
       document.documentElement.className = '';
     </script>
-    <!-- Debug script -->
-    <script src="/debug-blank-page.js"></script>
+    <!-- Debug script removed for production -->
     <script>
       // Add loading class but make sure it's removed within 1 second
       document.documentElement.classList.add('loading');
@@ -888,8 +887,7 @@
       // Loader code completely removed to eliminate CLS
     </script>
     
-    <!-- Simple debug script -->
-    <script src="/debug-page.js"></script>
+    <!-- Simple debug script removed -->
     
     <!-- EMERGENCY FIX: Ensure React app is loaded with fallbacks -->
     <script>


### PR DESCRIPTION
## Summary
- remove temporary debug scripts from production index

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run typecheck`
- `npm test` *(fails: vitest not found)*