### PR TITLE
Update Vercel build command

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -13,7 +13,7 @@
       ]
     }
   ],
-  "buildCommand": "npm run build",
+  "buildCommand": "npm run vercel-build",
   "outputDirectory": "dist",
   "framework": "vite"
 }


### PR DESCRIPTION
## Summary
- update `buildCommand` in `vercel.json` to use `npm run vercel-build`

## Testing
- `npm test` *(fails: vitest not found)*